### PR TITLE
Fix formatting for codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,4 @@
 # All of the people (and only those people) from the matching rule will be notified
 
 # Default rule: anything that doesn't match a more specific rule goes here
-* @radius-project/maintainers-radius @radius-project/approvers-radius
-* @sk593
+* @radius-project/maintainers-radius @radius-project/approvers-radius @sk593


### PR DESCRIPTION
Codeowners aren't getting added to PRs automatically, so trying a formatting fix