### PR TITLE
Add dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+	"name": "radius-bicep-types-aws",
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {},
+		"ghcr.io/devcontainers/features/go:1": {},
+		"ghcr.io/devcontainers/features/aws-cli:1": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"amazonwebservices.aws-toolkit-vscode",
+				"GitHub.copilot",
+				"golang.go",
+				"ms-azuretools.vscode-bicep",
+				"redhat.vscode-yaml"
+			]
+		}
+	}
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,7 @@ updates:
       all:
         patterns:
           - "*"
+  - package-ecosystem: "devcontainers"
+    directory: "/.devcontainer"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Adds a dev container to the repo, based on the instructions and dependencies defined in the [contributing readme](https://github.com/radius-project/bicep-types-aws/blob/main/docs/contributing/contributing-code/contributing-code-building/README.md).