### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,2 @@
-# Documentation and examples for what this does:
-#
-#  https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
-
-# This file is a list of rules, with the last rule being most specific
-# All of the people (and only those people) from the matching rule will be notified
-
-# Default rule: anything that doesn't match a more specific rule goes here
-* @radius-project/maintainers-radius @radius-project/approvers-radius @sk593
+# These owners are the maintainers and approvers of this repo
+*       @radius-project/maintainers-bicep-types-aws @radius-project/approvers-bicep-types-aws

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-# These owners are the maintainers and approvers of this repo
-*       @radius-project/maintainers-bicep-types-aws @radius-project/approvers-bicep-types-aws
+# See the owners for this repo at .github/CODEOWNERS


### PR DESCRIPTION
Combining two codeowners files into one, with root level pointing to the file under the `.github` directory. More context in https://github.com/radius-project/radius/issues/8074.
