### PR TITLE
Add EC2 to skipped resources

### DIFF
--- a/src/aws-type-downloader/main.go
+++ b/src/aws-type-downloader/main.go
@@ -20,6 +20,7 @@ import (
 // These have been skipped due to missing schema: https://github.com/aws/aws-sdk-go-v2/issues/2913
 // These will be reverted when the issue is resolved.
 var skippedResources = map[string]struct{}{
+	"AWS::EC2::LaunchTemplate":   {},
 	"AWS::QuickSight::Analysis":  {},
 	"AWS::QuickSight::Dashboard": {},
 	"AWS::QuickSight::Template":  {},


### PR DESCRIPTION
Same issue as https://github.com/radius-project/bicep-types-aws/pull/96. Detected in this workflow run: https://github.com/radius-project/bicep-types-aws/actions/runs/12206519359/job/34056128434?pr=97