### PR TITLE
Add back publish environment to workflow

### DIFF
--- a/.github/workflows/publish-bicep.yaml
+++ b/.github/workflows/publish-bicep.yaml
@@ -45,6 +45,7 @@ jobs:
   build-and-push-bicep-types:
     name: Publish Radius bicep types to ACR
     runs-on: ubuntu-latest
+    environment: publish-bicep
     steps:
       - name: Get GitHub app token
         uses: tibdex/github-app-token@v2


### PR DESCRIPTION
This PR adds the publish environment back to the publish workflow. This was originally removed when the approval workflow was added since the approval workflow runs on the publish environment, but the runs fail during release-triggered events (with the same error we ran into before where Github credentials had to be added per branch). 