### PR TITLE
Adding on-call team as owner specifically for dependency version updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
 # These owners are the maintainers and approvers of this repo
 *       @radius-project/maintainers-bicep-types-aws @radius-project/approvers-bicep-types-aws
+
+# Specific ownership for go.mod and go.sum in the root directory to allow the on-call team to approve dependency version updates (Dependabot PRs)
+/go.mod  @radius-project/on-call
+/go.sum  @radius-project/on-call


### PR DESCRIPTION
Adding on-call team as owner specifically for go.mod and go.sum for dependency version updates (Dependabot PRs)