### PR TITLE
Update go.mod directory path in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 *       @radius-project/maintainers-bicep-types-aws @radius-project/approvers-bicep-types-aws
 
 # Specific ownership for go.mod and go.sum in the root directory to allow the on-call team to approve dependency version updates (Dependabot PRs)
-/go.mod  @radius-project/on-call
-/go.sum  @radius-project/on-call
+src/aws-type-downloader/go.mod  @radius-project/on-call
+src/aws-type-downloader/go.sum  @radius-project/on-call


### PR DESCRIPTION
go.mod is under src/aws-types-downloader instead of root. Updating the directory in codeowners accordingly.