### PR TITLE
Adding on-call team as owner for package.json and package-lock.json files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,10 @@
-# These owners are the maintainers and approvers of this repo
-*       @radius-project/maintainers-bicep-types-aws @radius-project/approvers-bicep-types-aws
+# General maintainers and approvers for the entire repository
+* @radius-project/maintainers-bicep-types-aws @radius-project/approvers-bicep-types-aws
 
-# Specific ownership for specific files to allow the on-call team to approve dependency version updates (Dependabot PRs)
+# Ownership for dependency-related files. Allow the on-call team to approve dependency version updates (e.g., from Dependabot PRs)
+# Files in `src/aws-type-downloader`
 src/aws-type-downloader/go.mod  @radius-project/on-call
 src/aws-type-downloader/go.sum  @radius-project/on-call
+# Files in `src/aws-type-generator`
 src/aws-type-generator/package-lock.json @radius-project/on-call
 src/aws-type-generator/package.json @radius-project/on-call

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,8 @@
 # These owners are the maintainers and approvers of this repo
 *       @radius-project/maintainers-bicep-types-aws @radius-project/approvers-bicep-types-aws
 
-# Specific ownership for go.mod and go.sum in the root directory to allow the on-call team to approve dependency version updates (Dependabot PRs)
+# Specific ownership for specific files to allow the on-call team to approve dependency version updates (Dependabot PRs)
 src/aws-type-downloader/go.mod  @radius-project/on-call
 src/aws-type-downloader/go.sum  @radius-project/on-call
+src/aws-type-generator/package-lock.json
+src/aws-type-generator/package.json

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 # Specific ownership for specific files to allow the on-call team to approve dependency version updates (Dependabot PRs)
 src/aws-type-downloader/go.mod  @radius-project/on-call
 src/aws-type-downloader/go.sum  @radius-project/on-call
-src/aws-type-generator/package-lock.json
-src/aws-type-generator/package.json
+src/aws-type-generator/package-lock.json @radius-project/on-call
+src/aws-type-generator/package.json @radius-project/on-call


### PR DESCRIPTION
Building up on https://github.com/radius-project/bicep-types-aws/pull/131. Adding on-call team as owner for package.json and package-lock.json files for dependency version updates (Dependabot PRs).