### PR TITLE
Add maintainer/approver groups as dependency file owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,7 @@
 
 # Ownership for dependency-related files. Allow the on-call team to approve dependency version updates (e.g., from Dependabot PRs)
 # Files in `src/aws-type-downloader`
-src/aws-type-downloader/go.mod  @radius-project/on-call
-src/aws-type-downloader/go.sum  @radius-project/on-call
+src/aws-type-downloader/go.mod  @radius-project/on-call @radius-project/maintainers-bicep-types-aws @radius-project/approvers-bicep-types-aws
+src/aws-type-downloader/go.sum  @radius-project/on-call @radius-project/maintainers-bicep-types-aws @radius-project/approvers-bicep-types-aws
 # Files in `src/aws-type-generator`
-src/aws-type-generator/package-lock.json @radius-project/on-call
-src/aws-type-generator/package.json @radius-project/on-call
+src/aws-type-generator/package*.json @radius-project/on-call @radius-project/maintainers-bicep-types-aws @radius-project/approvers-bicep-types-aws


### PR DESCRIPTION
Add maintainer/approver groups as dependency file owners: The most specific rule takes precedence over more general ones. This means that if a file or directory matches multiple rules, the one with the narrower scope (e.g., a specific file or subdirectory) will override more general ones (e.g., the root * rule). So we need to add maintainer/approver teams explicitly to the files that oncall team is added as owner for.

Validated similar update in the Radius repo as well - https://github.com/radius-project/radius/pull/8933