### PR TITLE
Fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This repo contains the tooling for Bicep support for AWS types. The tools in thi
 
 ## Summary
 
-Browse our guides for how to [understand the code](./contributing-code/contributing-code-organization/)
-and [build the code](./contributing-code/contributing-code-building/).
-For information on how to contribute to Radius visit [Contributing](https://docs.radapp.dev/contributing/).
+Browse our guides for how to [understand the code](docs/contributing/contributing-code/contributing-code-organization/README.md)
+and [build the code](docs/contributing/contributing-code/contributing-code-building/README.md).
+For information on how to contribute to Radius visit [Contributing](https://docs.radapp.io/contributing/).
 For any other general information on Radius Visit [Radius](https://github.com/radius-project/radius) 
 
 ## Security

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -5,4 +5,4 @@ If you see a warning describing an AWS resource as 'non-idempotent', this means 
 
 We are currently building support for non-idempotent resources in Radius. Please like and comment on [this issue](https://github.com/radius-project/radius/issues/6227) if you are interested in the same.
 
-As a workaround, you can try using [Terraform Recipes](https://docs.radapp.dev/guides/recipes/overview/) to deploy and manage those non-idempotent resource types.
+As a workaround, you can try using [Terraform Recipes](https://docs.radapp.io/guides/recipes/overview/) to deploy and manage those non-idempotent resource types.


### PR DESCRIPTION
This pull request updates documentation links in the `README.md` file to point to the correct locations and updates the URL for the Contributing guide to use the `.io` domain.

Documentation updates:

* Updated internal documentation links in `README.md` to point to the correct `docs/contributing/contributing-code` subfolders.
* Changed the external Contributing guide link to use `radapp.io` instead of `radapp.dev` in `README.md`.

Fixes #166